### PR TITLE
Refactor Evaluator to enforce language support and add tests

### DIFF
--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -3,14 +3,17 @@ import type { Language } from './types.tsx'
 type WorkerResult = { result: unknown; ticks: number; error: unknown }
 type Result = { result: unknown; ticks: number[]; error: unknown }
 
-function execute(workerUrl: URL, script: string) {
+function execute(language: Language, script: string) {
 	let resolve!: (data: WorkerResult) => void
 	let reject!: (err: unknown) => void
 	const promise = new Promise<WorkerResult>((res, rej) => {
 		resolve = res
 		reject = rej
 	})
-	const worker = new Worker(workerUrl, { type: 'module' })
+	if (language !== 'JavaScript / TypeScript') {
+		throw new Error('Unsupported language')
+	}
+	const worker = new Worker(new URL('./workers/Engine262.ts', import.meta.url), { type: 'module' })
 	worker.onerror = (event) => {
 		worker.terminate()
 		reject(event.error ?? new Error('Worker failed to load'))
@@ -27,15 +30,6 @@ function execute(workerUrl: URL, script: string) {
 
 export default class {
 	static evaluate(language: Language, script: string[]): Promise<Result> {
-		let workerUrl: URL
-		switch (language) {
-			case 'JavaScript / TypeScript':
-				workerUrl = new URL('./workers/Engine262.ts', import.meta.url)
-				break
-			default:
-				throw new Error('Unsupported language')
-		}
-
 		let mergedSegments: string = ''
 		const promises: Promise<WorkerResult>[] = []
 		script.forEach((segment) => {
@@ -45,7 +39,7 @@ export default class {
 			mergedSegments += segment
 			promises.push(
 				new Promise((resolve) => {
-					execute(workerUrl, mergedSegments).then((res) => {
+					execute(language, mergedSegments).then((res) => {
 						resolve(res)
 					})
 				}),

--- a/tests/Evaluator.test.ts
+++ b/tests/Evaluator.test.ts
@@ -1,0 +1,7 @@
+import Evaluator from '../src/Evaluator.ts'
+import { assertEquals } from 'jsr:@std/assert@1.0.18'
+
+Deno.test('Evaluator', async () => {
+	const result = await Evaluator.evaluate('JavaScript / TypeScript', ['true'])
+	assertEquals(result.result, true)
+})

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -1,5 +1,0 @@
-import { assertEquals } from 'jsr:@std/assert@1.0.18'
-
-Deno.test('Placeholder', () => {
-	assertEquals(true, true)
-})


### PR DESCRIPTION
- Updated the `execute` function to accept a `Language` parameter and throw an error for unsupported languages.
- Removed the worker URL switch-case logic from the `evaluate` method.
- Added a new test for the `Evaluator` class to verify JavaScript execution.
- Deleted the placeholder test file as it was no longer needed.